### PR TITLE
Switch to results without conditioned profiles and show GeckoView WebRender

### DIFF
--- a/src/awfy.js
+++ b/src/awfy.js
@@ -14,6 +14,7 @@ const COLORS = {
   chromium: '#9DD866',
   fennec: '#9DD866',
   geckoview: '#6F4E7C',
+  'geckoview-webrender': '#92110c',
   fenix: '#FFA056',
   'fenix-webrender': '#e5ca0f',
   firefox: '#FFA056',
@@ -970,6 +971,7 @@ const MOBILE_APPS = {
   'chrome-m': {
     name: 'chrome-m',
     label: 'Chrome',
+    extraOptions: ['nocondprof'],
   },
   fenix: {
     name: 'fenix',
@@ -979,7 +981,7 @@ const MOBILE_APPS = {
   'fenix-webrender': {
     name: 'fenix',
     label: 'Fenix-WebRender',
-    extraOptions: ['webrender'],
+    extraOptions: ['webrender', 'nocondprof'],
   },
   fennec: {
     name: 'fennec',
@@ -990,6 +992,13 @@ const MOBILE_APPS = {
     name: 'geckoview',
     label: 'GeckoView',
     project: ALT_PROJECT,
+    extraOptions: ['nocondprof'],
+  },
+  'geckoview-webrender': {
+    name: 'geckoview',
+    label: 'GeckoView WebRender',
+    project: ALT_PROJECT,
+    extraOptions: ['webrender', 'nocondprof'],
   },
 };
 


### PR DESCRIPTION
@airimovici when trying to push this I had test failures:

```
husky > pre-push (node v15.4.0)
$ jest
 PASS  test/chartJs.test.js
 PASS  test/config.test.js
 PASS  test/fetchAndCache.test.js
 PASS  test/fetchWrapper.test.js
 PASS  test/components/Pickers.test.jsx
 FAIL  test/perfherder.test.js (11.241s)
  ● Perfherder › Windows 10 › Tp5o opt (no subtests)

    : Timeout - Async callback was not invoked within the 5000ms timeout specified by jest.setTimeout.Timeout - Async callback was not invoked within the 5000ms timeout specified by jest.setTimeout.Error:

      77 |     };
      78 |
    > 79 |     it('Tp5o opt (no subtests)', async () => {
         |     ^
      80 |       seriesConfig.suite = 'tp5o';
      81 |
      82 |       const data = await queryPerformanceData(seriesConfig, { timeRange: TIMERANGE });

      at new Spec (node_modules/jest-jasmine2/build/jasmine/Spec.js:116:22)
      at Env.testFn [as it] (node_modules/setup-polly-jest/lib/jasmine.js:98:21)
      at Suite.<anonymous> (test/perfherder.test.js:79:5)
      at Suite.<anonymous> (test/perfherder.test.js:71:3)
      at Object.<anonymous> (test/perfherder.test.js:28:1)
      at processTicksAndRejections (node:internal/process/task_queues:93:5)

  ● Perfherder › Windows 10 › sessionrestore

    : Timeout - Async callback was not invoked within the 5000ms timeout specified by jest.setTimeout.Timeout - Async callback was not invoked within the 5000ms timeout specified by jest.setTimeout.Error:

      92 |     });
      93 |
    > 94 |     it('sessionrestore', async () => {
         |     ^
      95 |       seriesConfig.suite = 'sessionrestore';
      96 |
      97 |       const data = await queryPerformanceData(seriesConfig, { timeRange: TIMERANGE });

      at new Spec (node_modules/jest-jasmine2/build/jasmine/Spec.js:116:22)
      at Env.testFn [as it] (node_modules/setup-polly-jest/lib/jasmine.js:98:21)
      at Suite.<anonymous> (test/perfherder.test.js:94:5)
      at Suite.<anonymous> (test/perfherder.test.js:71:3)
      at Object.<anonymous> (test/perfherder.test.js:28:1)
      at processTicksAndRejections (node:internal/process/task_queues:93:5)

Test Suites: 1 failed, 5 passed, 6 total
Tests:       2 failed, 18 passed, 20 total
Snapshots:   1 passed, 1 total
Time:        12.141s
Ran all test suites.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
husky > pre-push hook failed (add --no-verify to bypass)
error: failed to push some refs to 'git@github.com:davehunt/firefox-performance-dashboard.git'