### PR TITLE
Refresh polly recordings

### DIFF
--- a/test/recordings/Perfherder_169537080/Linux64_2717411455/Kraken-no-subtests-_2260542550/recording.har
+++ b/test/recordings/Perfherder_169537080/Linux64_2717411455/Kraken-no-subtests-_2260542550/recording.har
@@ -269,7 +269,7 @@
         }
       },
       {
-        "_id": "a044f6e053af91e4bc7157a2f1b8516f",
+        "_id": "b54663ab88e35a4c258cace87faa23b2",
         "_order": 0,
         "cache": {},
         "request": {
@@ -301,7 +301,7 @@
               "value": "treeherder.mozilla.org"
             }
           ],
-          "headersSize": 296,
+          "headersSize": 315,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -314,19 +314,23 @@
               "value": "172800"
             },
             {
+              "name": "no_retriggers",
+              "value": "true"
+            },
+            {
               "name": "signature_id",
               "value": "1928883"
             }
           ],
-          "url": "https://treeherder.mozilla.org/api/project/autoland/performance/data/?framework=1&interval=172800&signature_id=1928883"
+          "url": "https://treeherder.mozilla.org/api/project/autoland/performance/data/?framework=1&interval=172800&no_retriggers=true&signature_id=1928883"
         },
         "response": {
-          "bodySize": 780,
+          "bodySize": 822,
           "content": {
             "_isBinary": true,
             "mimeType": "application/json",
-            "size": 780,
-            "text": "[\"1f8b08000000000002ff8d96db8a1c470c86df65ae97412a1d4af2ab04134a754836c407bcbbbe317ef7689680bb8634998b81a19aaefe5afaf555ffb8f882de4b083921b43e8875b6d9b19588a14475728b51f8f2e1b71f97e771f980a596c240884f9797e73f3eb7d7b76ff3f7f72b5ecc8c9e2e7f7d89f7052acc0205f5e9f2f5ede5cff73523f6920bdfe6f7e797e72f9f2f1f2eb93b076860b4950fe759741650cca50a4648d2211aadcbbfdbbc3e7f9a2fafedd3d77ca442750128f674f9defe7e9b373ef62bfc7cfa454be240f210ad6a51d86805d0365a9f3878044f19d073df32a45b93e6dc8317203952af50ce68158ad28196e4ea475a76677b8cd64af2eeb4f9f61b2d95e5ead1b8966ebc041234448ad89cd1c01ae0a4817a465b01418eb5c56b39d22ad6047e8456a072b9a32de47b122c4616687958e9cd86cf450c6db299560acdac82aacf335a433438d2ea958eb4995cf0f2106da1227b6e2593bbd19691770ea6526b8416c27064915a06807817575e9eef7346eb051df7dceeb49633690fd112e1ad0b475a66d89340e60db2098864c11d72d47bf3151a11c5146665ca02ff37ad0158deb7d7b61e6973aaab3ce4046165949d56ee9c6035eb335301280d42b9694376e3b16610e4d51ee11074465bb2817ca095bae596a090da63b9ad4474e704ad7753a623fbcea02dd68ae69ec2c29efd1759994a5bf9f381274e30e022b7f6fdaaad6d0623cca6c963b97570bc4b82dd390183fa108d5e47a4586d3559907ffb8a54536e92d592b9e08c5698ead109a2573dd2524ae156fcffa7d5dbecdcd1faed450fb44256b3fd395bc0c1dcbbafb40232b97018a50ec6ec41ed8c56b3b49bc1ead5365aabc8fa18ad641f37da9479dd68c357e7aa3d010b0e88cab522e46999b3ceadd4091d7dea89c12cc713ea31b754af7ca44d13a6141ea295e2b6e7569168a35d19cd96c55bea803ec0662f305a6965a9b6eeddf2a4503a4d82e79cf1ee842db7228e8f4d996a1e3478476bbb13669ab5454e7ece92d420cf33382590e77f94a0395dd76c154fbe132c0f3286adb69a4ef8f8f31f038faed004090000\"]"
+            "size": 822,
+            "text": "[\"1f8b08000000000002ff8d96eb8a23470c85dfa57f1b23a97429edab8425d4359990bdb033b37f9679f7a88790ed72e8a40d06d365dc9f8fce39ea1f9b4f688daa244f08a5f5c43aca6858a8d6ae29d9e0523bf1f6e1971fdb53df3e201939a909deb6e7a7df3e9797d76fe3d7f713a79c73ba6d7f7ca9ef1712b1b032ca6dfbfafafcfbfbb59c44486fdbb7f1fde9f9e9cbe7edc396cddc0782a214a8ca450bb267ee73d40471da6a75a869fbfb675e9e3e8de797f2e96bdc5221030925be6ddfcb9faf63e713bbd3dbed1fda049434fb255a4b29c14aabc60b6dd22e620c5aea9cb5b837a8d85c59649ae73ce3ed1de98c9649dc0fb49cef70a4454614ba44ebe0e82b6da695166b6a5db436eb156ac9b3c884f8d866a5982e058dc99870462b9c4c8edaea5d8fb449d176f1ff9f5613c59c575adfffe8815652b6187f7504aeccadf91c3314492e5c7352f53e5a4de58c5643da232ddb3d2fb4d990f51aadc41c175a05b285b6fa6c6cda0290b043353643808484ce856c40431f3ace68c34476f46db23b1f69398c942ea54c853cafbe554c69a19d61cd12e24d7540ef904723e8850a4dd5d2bc6589e9a6532778e4ec48cbbafa56c4f15aca5401011f68f3da09c3a8971ac98f2c89d5e43c244ac0052ad53486eb1cc5709ed0621817166d75ed84688d40be44eb99c056da24abb65cc61ebd9162f60c634eabb3a7da514b4aec18874d14ceb44552353b6a4b775b6805395fa2dd0db8876aa1b5d5b712bdea58224a3902a739beb0e7cb3a23b90ea610bf4cd1535acf988fb4bed0326666b99432e328e7075ad917cb81b67198a529214687c18c1706a4366e5e3975e98d6c829fa50c99291dfb56f19e165ab7f7f95ea28dbe7ba45d1bccdb44cd056d3a40e96e4513ea34e81e352b933b699324ff41ab4bcae48e475aca2e7aa96f4df2bf9ca0bad2ce0e161618910f54518ae56b3eccca046a164983e9dcf96cf3623c35ec83feb91df82e47da28c408da25daf0213d34589607df7ad510b4ed559cf63ec8b102d95b2f9dcaa09ea1688bf49dd19af3eead9fb469d90ecc4eef35748536abcb03edbe278f4e98fba355542be884dc63537b41ca325c4ac696d5b428483da38d3aceb63a01de3ebefd059814ecddb2090000\"]"
           },
           "cookies": [],
           "headers": [
@@ -340,7 +344,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 16 Dec 2020 11:09:09 GMT"
+              "value": "Thu, 17 Dec 2020 08:20:53 GMT"
             },
             {
               "name": "content-type",
@@ -356,7 +360,7 @@
             },
             {
               "name": "content-length",
-              "value": "780"
+              "value": "822"
             },
             {
               "name": "content-encoding",
@@ -393,8 +397,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-12-16T11:09:09.449Z",
-        "time": 532,
+        "startedDateTime": "2020-12-17T08:20:52.022Z",
+        "time": 703,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -402,7 +406,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 532
+          "wait": 703
         }
       }
     ],

--- a/test/recordings/Perfherder_169537080/Windows-10_2105768759/Tp5o-opt-no-subtests-_3522863577/recording.har
+++ b/test/recordings/Perfherder_169537080/Windows-10_2105768759/Tp5o-opt-no-subtests-_3522863577/recording.har
@@ -269,7 +269,7 @@
         }
       },
       {
-        "_id": "580f254669716f28021edefc78dc8a98",
+        "_id": "b47a76ad46a71622c160002066db3ead",
         "_order": 0,
         "cache": {},
         "request": {
@@ -301,7 +301,7 @@
               "value": "treeherder.mozilla.org"
             }
           ],
-          "headersSize": 296,
+          "headersSize": 315,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -314,19 +314,23 @@
               "value": "172800"
             },
             {
+              "name": "no_retriggers",
+              "value": "true"
+            },
+            {
               "name": "signature_id",
               "value": "1925964"
             }
           ],
-          "url": "https://treeherder.mozilla.org/api/project/autoland/performance/data/?framework=1&interval=172800&signature_id=1925964"
+          "url": "https://treeherder.mozilla.org/api/project/autoland/performance/data/?framework=1&interval=172800&no_retriggers=true&signature_id=1925964"
         },
         "response": {
-          "bodySize": 781,
+          "bodySize": 817,
           "content": {
             "_isBinary": true,
             "mimeType": "application/json",
-            "size": 781,
-            "text": "[\"1f8b08000000000002ff8d96db6a64371045ffe53c9ba6eeaaf2af8410744d1c3217c6f6bc0cfef7944dc0474d1afaa19b466a49eb6cedda757e1d7dd6d1860a198083e7f7a45abc8dc113050a934c9821c7e36fbf8ea7713c221522360a78389e9ffefc5a5f5e7fcc3f3e6682344c1e8ebfbfb58f815c2b1245fde1f8fefafcd7c798b304d9c3f163fe7c7a7efaf6f5783c46fead81356c75d9ac32c92681610e157046d60eadf23afedbe6e5e9cb7c7ea95fbee79106251480f2889ff59fd7793c92c7c5e8ede19396430ac95db416803bad7e0c9c6863e290d164ea800eac34b47bd51ad29b2c400ee45e806ed11a90f127adf2a5e09956f24ca6bb689d2262a7c5f7073dd132adb0683515e82e4b21419b2aa9cfd92a78059c3cd06ed11640d04fda800bfa99d652eeb07b6815220477dabc9add09e9bb14684573ead547ccc502758abb156eb65271b398b7681dd1e1e404bf7839d316c274d55db4c41a574e48e76eb43472e510a6525a33626c81a25a680068f4f73d57e4f3dca20dc2c0cdb7bad37a71baabca9459cd765a11d89dc01e15a008227b930e83a5d758cd5a6b94853f8b700afcffb49ee990eb4eb4760139d3e60ecef7d18a81c24eab5799e025f5997959a8159a49b58a122e63cdc690b3bdb580c6b768292f50366d994fb49c421097bb680b295ef9d6ca5595d9c87b17b0dad66a3522030b7beea4bad295bef213036f648283e4b171ca04dc132c23d0c5f12eda40d42b5abfca046cdc875aeb65b40c565f5517e4cfbe5a46536e425a742eb845abc2e594095e2e65d336670bc43db496d5cd574e08a58d56d94b5e7fd6164813e93d56a6020a874a73ce3818b337aeb7682da5d52d1370837524bd2b1212d65136d8ccf2b2c1b6585d8af5e4231cd08a9482008c59ea52a94ce818d36e0498677542d96d8b1bad643ada5db6b5cc84d8a53564de68573ab3a676ebbdedc5009f9d6054aab4cc6a8feed9288c6f1a21b2cc649356cfcd21ab3ae45dfb3b680dc4ed8ad6f7489819acb565e167296969d9d5a7660664fb6fd478ceb0356bc11baf099e7d4c60d7b694b7dfdffe05d37e8db703090000\"]"
+            "size": 817,
+            "text": "[\"1f8b08000000000002ff8d96eb8a23371085dfa57f0fa64aaaebbc4a5882ae8943f6c2ceccfe59e6dd533d846ccbd0a10d36a6254b1f47e71cf9e7d646e9b533250130b0f81ca9a8d5def34002cd89060ca7edf9b79fdbbd6fcf9834c534cbf0b4bddcfff8525edfbe8fdf3f463cb10b3d6d7f7dad1f0fe2b74c021c33bfbdbdfcf9f1cc327392a7edfbf8717fb97ffdb23d6fa6ea3e1004b940152a5290dca8cf5133c468abd5a1e6eddf655eef9fc7cb6bf9fc2db60c10489c72ecfaa3fcfd36b6e7647ecbf9fde93fda0ca029eb255a4d8cb8d28ad2429ba5332b81943a672dee0d2ab6588979aa9bcd787bc774464bb1adffa265bc493ad2623632bc44eb88fc406b69a5c59a5b67a94d7b855a6c169e105fdbac49722c9258794c38a365caca076df5a68bb631aae057682513e4072738a78596b3691c7f7504aa44adf91c33236567aa9645bc8f567339a39590f6486b375c600d13cb4558435a6005922eb0d5672395167c093b54255504c898d0a9241dd0d0878c33d8f090aeb6c585965c402ed95638675fa515cc79a19de1cc12da4d7140ef60a325e8259534454af3661cdae4532378c48c1669d98eb4cc4ebbf6176805c8e481d6d64a189a7aa911fc88126bcd4e83a3039ca1a69ac77099a328ce135a0cdfc2aaadea91766fa16b4e5050ce0f4ec8bc6a4b65ecc91b39ce9e60cca975f65c3b4ac9718c18838da359cf689388ea2f5a871baeb49c5dec126d04c7f8815657df72d4aa638924c5ba261613f67869274c2e8352885f26cb29ad1bda81166f76a4258cb47abe441be5e2b6d2f2de6807da4608d824214685c18c1706a4346a5e2977ee2de9043f4b1912a57cacdb7c335c6835aeb84b05a6c466f448bb1698b7896205753a40e9ae4532ca54e81e2dcb937a92c699ff87560ebe65bea11c69a380c5af39818df283134456dad97773dbc014902c29ee5ef5a15a26a4a69134984e9dce2e5e0c5bee213a74021d3b8148cc2c5da2358ec4aeb4c60fbef52a2168dbab38ef7d60b4774eeba5a732523728d2227d67b4eab47beb484b0bad47ca2e3598c60dcf0fbeb5fd9a3c3a61fa8416d50a32c1baa37bc1643c9c8b61335129f1d7a89ed1461d9b2e176fb2f74fefff008a89c262b1090000\"]"
           },
           "cookies": [],
           "headers": [
@@ -340,7 +344,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 16 Dec 2020 11:09:11 GMT"
+              "value": "Thu, 17 Dec 2020 08:20:53 GMT"
             },
             {
               "name": "content-type",
@@ -356,7 +360,7 @@
             },
             {
               "name": "content-length",
-              "value": "781"
+              "value": "817"
             },
             {
               "name": "content-encoding",
@@ -393,8 +397,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-12-16T11:09:10.601Z",
-        "time": 592,
+        "startedDateTime": "2020-12-17T08:20:52.742Z",
+        "time": 601,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -402,7 +406,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 592
+          "wait": 601
         }
       }
     ],

--- a/test/recordings/Perfherder_169537080/Windows-10_2105768759/sessionrestore_1993046815/recording.har
+++ b/test/recordings/Perfherder_169537080/Windows-10_2105768759/sessionrestore_1993046815/recording.har
@@ -269,7 +269,7 @@
         }
       },
       {
-        "_id": "be227399f31d82eb04e8b116fe63cbee",
+        "_id": "fd30ff8438118dd1ff6e33aa731a9022",
         "_order": 0,
         "cache": {},
         "request": {
@@ -301,7 +301,7 @@
               "value": "treeherder.mozilla.org"
             }
           ],
-          "headersSize": 296,
+          "headersSize": 315,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -314,19 +314,23 @@
               "value": "172800"
             },
             {
+              "name": "no_retriggers",
+              "value": "true"
+            },
+            {
               "name": "signature_id",
               "value": "1924060"
             }
           ],
-          "url": "https://treeherder.mozilla.org/api/project/autoland/performance/data/?framework=1&interval=172800&signature_id=1924060"
+          "url": "https://treeherder.mozilla.org/api/project/autoland/performance/data/?framework=1&interval=172800&no_retriggers=true&signature_id=1924060"
         },
         "response": {
-          "bodySize": 764,
+          "bodySize": 807,
           "content": {
             "_isBinary": true,
             "mimeType": "application/json",
-            "size": 764,
-            "text": "[\"1f8b08000000000002ff8d96db6aee460c85dfc5d7a168741a29af524a19cda14de93eb093ec9bcd7ef72aa134fffcd4e00b83197beccfd25a4bfe7158349ee08c0d70f8581ad6d44b7369c5198a970a3c573b1e7ffd713c8de3b160452484420fc7f3d31f9fdbcbebb7f9fbfb1547068587e3af2ff1be40c8cc5e991f8eafafcf7fbeaf19b1a33e1cdfe6f7a7e7a72f9f8fc763e46d011a25dad29938a813414b2e55302a241da2d13afe7dcccbd3a7f9fcd23e7dcd572a541700b487e37bfbfb751e8fc2f40bfc7cf88025abe87c09561d10365881621baccf3278044f19d0810487746bd29c7bf0caaa78a15e01cf601550e906d67658aee6ec97600dfd1eb6206fb084cbd5b3c315bbf11248ce1041b139a38135289346d133d80a05e403967487554c0cbc022be0d9851d16c97719588c2ccff230eccd86cf450c6db299560a5d596f559f67b0568ac14d656187adc544f4122c9202edb0c43b2c8edc3998b0d608452ae185452a0e00f12eaebc3c3fe70cd6319df51f2ceb9d0caa09bf09ef022c91b8ecb0ccb0cb80cc1b40e552c8823b0ce2de7c8546049ac2ac4c59deff873500cb7d1fb0f5ce60265ab55e82652d6f77dec2ca5d1a58cdeacc347f9106a1dcb41576e3b16610e4d51ee11074068bd93e3ed52c0170add734fbe6c63dbaf243ef0ca6239b9e5b5bac15cd3d93aaf46cbec84a45dacac347394903034671bf812d3b6ca6496ae512aca7f7ef346b77695082fa108d5e4764a0da6ab2204ffb8acca47c084a95b9e00c3693b5dea481f80e4b3936a45c8155e22277d1e5821bac646c67efd356c0c1dcbbafcc83c2e4c261944130660f6a67b09a85bd81e57bd82a22976490b0d576cd6686d70d367c75aeda930fcb80a8a9b10240255dce0deb845e7cea4974593a13eaad66f7e87a9b9808972698665071d9610bd106bb52962d4bb772da151f60b3238c860d976aebde2d0784d2a90c7246ca0dacec69908666d36b325060a53b58dbd36066a2b648cfa78da406790edeb47fcefcc0a0395dd76cb59cfc1b588e2f86fb34f8ede73f2e0ad8a0f7080000\"]"
+            "size": 807,
+            "text": "[\"1f8b08000000000002ff8d96eb8a24370c85dfa57e37419275b1e6554208be2613b2177666f6cfb2ef1ed51076cb05b55443436357bb3ecbe71cf9db966be101ce5480baf7a93517752c2e059d011d0d78ccb23dfdfe6d7beedb1392511635b5c7f6f2fcd7c7f2faf665fcf93ee3c4a0f0d8fef954df0712b1b0e2fee4e7b797bfdfc77212217d6c5fc6d7e797e74f1fb7a72d9bb90f04452950958b1664cfdce7a80962b6d5ea50d3f6ff32afcf1fc6cb6bf9f0395ea9908184123fb6afe5dfb7b13d49d2dfe0fbe3076c026033ba056bc4c62bacee0307d8a45dc4e2afa5ce598b7b838acd9545a679ce33bede91ae6099c4fd008b2b2c2607f35bb08ec46985cdb4c2624dad8bd666bd422d791699103fdbaca4291621311913ae608593c94f58f11536855004efc06a621458615d688195942dcebe3a0257e6d67c8e9990930bd79c54bd8f5653b982d528ec0196cfb02622b76410b09657cd2a902db0d56763d3167c841daa85c6102021856b0ad980863e745cc18682eca8595861d989806fc14a62c61516535a6067c8b244e9a67a18ba431e8da0172a34554bf3968544d3a50c3c2c768095b4c28a70d67b325088ea9e60f39a06c3a8971a9e0f1b89d5e43c24ecef02956a1ac3758e62382f6031440bbf48834c18a97607d6e28476b6236c92b5b25cc6eeba91e2e019c69c56674fb5a39614878831d944e1aab248aa6687cada093679925b3208f131c209d656cd4ae469247bb82887d734c703bbb5ac3392eb608ad297297a09eb19f3c160b2c0f2be59ba155dc6b1b35365650f92036c8bed6053428cf082191f0c466ddcbc72ead21bd904bf32183253fa99b39ccfb09a0df41eac44adceb06b74799bb160419b0e50ba5bd1843a0dba47bccae44eda24c92f60f568b0350d98320bdc6ab72659805658d5157676b038ff81148ca2141dd77c989509d42c4c06d3b9f355bb458940d6830c788565a5680bb760730487afb0594e9af5aa51ceb64770da93204ae1ecad974e6550cf50b485f1ae60cd7917d68f34482758c7f7be7407363b9d0c96f7e67894c1f4092d22157442ee8eee05e3b234e23295b1e5b8341505a957b011c3f9900669afec1fdfff0303b57324a4090000\"]"
           },
           "cookies": [],
           "headers": [
@@ -340,7 +344,7 @@
             },
             {
               "name": "date",
-              "value": "Wed, 16 Dec 2020 11:09:12 GMT"
+              "value": "Thu, 17 Dec 2020 08:20:54 GMT"
             },
             {
               "name": "content-type",
@@ -356,7 +360,7 @@
             },
             {
               "name": "content-length",
-              "value": "764"
+              "value": "807"
             },
             {
               "name": "content-encoding",
@@ -393,8 +397,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-12-16T11:09:11.814Z",
-        "time": 538,
+        "startedDateTime": "2020-12-17T08:20:53.355Z",
+        "time": 567,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -402,7 +406,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 538
+          "wait": 567
         }
       }
     ],


### PR DESCRIPTION
A recordings refresh.
The recordings were out of date (the request recorded before did not have `no_retriggers=true`)

The changes were generated automatically by running `yarn test`