### PR TITLE
Stop using conditioned profiles for Fenix page load tests

### DIFF
--- a/src/awfy.js
+++ b/src/awfy.js
@@ -995,10 +995,12 @@ const MOBILE_APPS = {
     name: 'fenix',
     label: 'Fenix',
     project: 'fenix',
+    extraOptions: ['nocondprof'],
   },
   'fenix-webrender': {
     name: 'fenix',
     label: 'Fenix-WebRender',
+    project: 'fenix',
     extraOptions: ['webrender', 'nocondprof'],
   },
   fennec: {


### PR DESCRIPTION
acreskey noticed that we're missing Fenix data, which was caused by the disabling of conditioned profiles.