### PR TITLE
Add desktop live sites

### DIFF
--- a/src/awfy.js
+++ b/src/awfy.js
@@ -223,11 +223,19 @@ const DESKTOP_CATEGORIES = {
   },
   'cold-page-load': {
     suites: [],
-    label: 'Cold Page Load',
+    label: 'Cold Page Load (Recorded)',
+  },
+  'cold-page-load-live': {
+    suites: [],
+    label: 'Cold Page Load (Live)',
   },
   'warm-page-load': {
     suites: [],
-    label: 'Warm Page Load',
+    label: 'Warm Page Load (Recorded)',
+  },
+  'warm-page-load-live': {
+    suites: [],
+    label: 'Warm Page Load (Live)',
   },
   ...AWSY_CATEGORIES,
   network: {
@@ -448,6 +456,30 @@ Object.entries(SITES).forEach(([siteKey, siteLabel]) => {
       }
     });
     DESKTOP_CATEGORIES[`${cacheVariant}-page-load`].suites.push(bmKey);
+  });
+});
+
+Object.entries(SITES).forEach(([siteKey, siteLabel]) => {
+  ['cold', 'warm'].forEach((cacheVariant) => {
+    const bmKey = `raptor-tp6-${siteKey}-${cacheVariant}-live`;
+    BENCHMARKS[bmKey] = { compare: {}, label: siteLabel };
+    Object.entries(DESKTOP_APPS).forEach(([appKey, app]) => {
+      BENCHMARKS[bmKey].compare[appKey] = {
+        color: app.color,
+        label: app.label,
+        frameworkId: RAPTOR_FRAMEWORK_ID,
+        suite: siteKey,
+        application: app.name,
+        platformSuffix: app.platformSuffix,
+        project: app.project,
+        option: 'opt',
+        extraOptions: [cacheVariant, 'live'],
+      };
+      if (Array.isArray(app.extraOptions)) {
+        BENCHMARKS[bmKey].compare[appKey].extraOptions.push(...app.extraOptions);
+      }
+    });
+    DESKTOP_CATEGORIES[`${cacheVariant}-page-load-live`].suites.push(bmKey);
   });
 });
 

--- a/src/awfy.js
+++ b/src/awfy.js
@@ -436,50 +436,36 @@ const SITES = {
 
 Object.entries(SITES).forEach(([siteKey, siteLabel]) => {
   ['cold', 'warm'].forEach((cacheVariant) => {
-    const bmKey = `tp6-${siteKey}-${cacheVariant}`;
-    BENCHMARKS[bmKey] = { compare: {}, label: siteLabel };
-    Object.entries(DESKTOP_APPS).forEach(([appKey, app]) => {
-      BENCHMARKS[bmKey].compare[appKey] = {
-        color: app.color,
-        label: app.label,
-        frameworkId: BROWSERTIME_FRAMEWORK_ID,
-        suite: siteKey,
-        test: 'SpeedIndex',
-        application: app.name,
-        platformSuffix: app.platformSuffix,
-        project: app.project,
-        option: 'opt',
-        extraOptions: [cacheVariant, 'nocondprof'],
-      };
-      if (Array.isArray(app.extraOptions)) {
-        BENCHMARKS[bmKey].compare[appKey].extraOptions.push(...app.extraOptions);
+    [true, false].forEach((live) => {
+      let category = `${cacheVariant}-page-load`;
+      let bmKey = `tp6-${siteKey}-${cacheVariant}`;
+      if (live) {
+        bmKey += '-live';
+        category += '-live';
       }
+      BENCHMARKS[bmKey] = { compare: {}, label: siteLabel };
+      Object.entries(DESKTOP_APPS).forEach(([appKey, app]) => {
+        BENCHMARKS[bmKey].compare[appKey] = {
+          color: app.color,
+          label: app.label,
+          frameworkId: BROWSERTIME_FRAMEWORK_ID,
+          suite: siteKey,
+          test: 'SpeedIndex',
+          application: app.name,
+          platformSuffix: app.platformSuffix,
+          project: live ? PROJECT : app.project,
+          option: 'opt',
+          extraOptions: [cacheVariant, 'nocondprof'],
+        };
+        if (live) {
+          BENCHMARKS[bmKey].compare[appKey].extraOptions.push('live');
+        }
+        if (Array.isArray(app.extraOptions)) {
+          BENCHMARKS[bmKey].compare[appKey].extraOptions.push(...app.extraOptions);
+        }
+      });
+      DESKTOP_CATEGORIES[category].suites.push(bmKey);
     });
-    DESKTOP_CATEGORIES[`${cacheVariant}-page-load`].suites.push(bmKey);
-  });
-});
-
-Object.entries(SITES).forEach(([siteKey, siteLabel]) => {
-  ['cold', 'warm'].forEach((cacheVariant) => {
-    const bmKey = `raptor-tp6-${siteKey}-${cacheVariant}-live`;
-    BENCHMARKS[bmKey] = { compare: {}, label: siteLabel };
-    Object.entries(DESKTOP_APPS).forEach(([appKey, app]) => {
-      BENCHMARKS[bmKey].compare[appKey] = {
-        color: app.color,
-        label: app.label,
-        frameworkId: RAPTOR_FRAMEWORK_ID,
-        suite: siteKey,
-        application: app.name,
-        platformSuffix: app.platformSuffix,
-        project: app.project,
-        option: 'opt',
-        extraOptions: [cacheVariant, 'live'],
-      };
-      if (Array.isArray(app.extraOptions)) {
-        BENCHMARKS[bmKey].compare[appKey].extraOptions.push(...app.extraOptions);
-      }
-    });
-    DESKTOP_CATEGORIES[`${cacheVariant}-page-load-live`].suites.push(bmKey);
   });
 });
 


### PR DESCRIPTION
We only have firefox `cnn-ampstories` live results on raptor and with series name like `raptor-tp6-cnn-ampstories-firefox-cold`

https://treeherder.mozilla.org/perfherder/graphs?highlightAlerts=1&series=mozilla-central,2851268,1,10&series=mozilla-central,2852642,1,10&series=mozilla-central,2695035,1,10&series=mozilla-central,2695045,1,10&timerange=1209600

I assumed the suite names will be consistent with the mobile like: `amazon-search` , `microsoft-support`, `bbc`.