### PR TITLE
Add bookmarks for individual results

### DIFF
--- a/src/components/PerfherderGraph/index.jsx
+++ b/src/components/PerfherderGraph/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
+import BookmarkIcon from '@material-ui/icons/BookmarkBorder';
 import LinkIcon from '@material-ui/icons/Link';
 import ArrowDownward from '@material-ui/icons/ArrowDownward';
 import { withStyles } from '@material-ui/core/styles';
@@ -165,10 +166,13 @@ class PerferhderGraph extends React.Component {
         }) => (
           <div key={title}>
             {handleData(benchmarkUID)}
-            <h2 className={classes.benchmarkTitle}>{title}</h2>
+            <h2 id={benchmarkUID} className={classes.benchmarkTitle}>{title}</h2>
             {subtitle ? (
               <h3 className={classes.benchmarkTitle}>{subtitle}</h3>
             ) : null}
+            <a href={`#${benchmarkUID}`}>
+              <BookmarkIcon className={classes.linkIcon} />
+            </a>
             <a href={jointUrl} target="_blank" rel="noopener noreferrer">
               <LinkIcon className={classes.linkIcon} />
             </a>


### PR DESCRIPTION
I recently had the need to direct someone to results that were quite a way down the page, and thought it would be handy to have a way to link directly to a chart. I suppose I could have sent them to the subtest view, but not all charts have this. This patch is an attempt to add a named anchor and a linked icon for convenient copying, but it's not working as intended. When clicking, I get a page reload, and when using the full URL doesn't work because content loads asynchronously.

@airimovici do you have any ideas how I could make this work?