### PR TITLE
Bug 1699764 - Remove Facebook page load test using legacy design

### DIFF
--- a/src/awfy.js
+++ b/src/awfy.js
@@ -377,7 +377,6 @@ const SITES = {
   expedia: 'Expedia',
   facebook: 'Facebook',
   'facebook-cristiano': 'Facebook (page)',
-  'facebook-redesign': 'Facebook (redesign)',
   fandom: 'Fandom',
   fashionbeans: 'FashionBeans',
   google: 'Google',


### PR DESCRIPTION
I don't think we need to wait for the bug to be resolved, let's remove the results for the redesign and the remaining chart will show these results once the patch lands.