### PR TITLE
Android WebRender platforms and nocondprof removal

### DIFF
--- a/src/awfy.js
+++ b/src/awfy.js
@@ -226,12 +226,8 @@ Object.entries(RAPTOR_TESTS).forEach(([testKey, test]) => {
       platformSuffix: app.platformSuffix,
       project: app.project,
       option: 'opt',
-      // FIXME: chrome raptor benchmark tests do not contain 'nocondprod' extra option
-      extraOptions: appKey.startsWith('chrom') ? app.extraOptions : ['nocondprof'],
+      extraOptions: app.extraOptions,
     };
-    if (Array.isArray(app.extraOptions)) {
-      RAPTOR_BENCHMARKS[bmKey].compare[appKey].extraOptions.push(...app.extraOptions);
-    }
     DESKTOP_CATEGORIES.benchmarks.suites.push(bmKey);
   });
 });
@@ -250,12 +246,8 @@ Object.entries(RAPTOR_TESTS).forEach(([testKey, test]) => {
       platformSuffix: app.platformSuffix,
       project: app.project,
       option: 'opt',
-      // FIXME: chrome raptor benchmark tests do not contain 'nocondprod' extra option
-      extraOptions: appKey.startsWith('chrom') ? app.extraOptions : ['nocondprof'],
+      extraOptions: app.extraOptions,
     };
-    if (Array.isArray(app.extraOptions)) {
-      RAPTOR_BENCHMARKS[bmKey].compare[appKey].extraOptions.push(...app.extraOptions);
-    }
     DESKTOP_CATEGORIES.benchmarks.suites.push(bmKey);
   });
 });
@@ -398,7 +390,7 @@ Object.entries(SITES).forEach(([siteKey, siteLabel]) => {
           platformSuffix: app.platformSuffix,
           project: live ? PROJECT : app.project,
           option: 'opt',
-          extraOptions: [cacheVariant, 'nocondprof'],
+          extraOptions: [cacheVariant],
         };
         if (live) {
           BENCHMARKS[bmKey].compare[appKey].extraOptions.push('live');
@@ -492,7 +484,7 @@ Object.entries(SITES).forEach(([siteKey, siteLabel]) => {
           platformSuffix: app.platformSuffix,
           project: app.project,
           option: 'opt',
-          extraOptions: [cacheVariant, 'nocondprof'],
+          extraOptions: [cacheVariant],
         };
         if (live) {
           BENCHMARKS[bmKey].compare[appKey].extraOptions.push('live');

--- a/src/awfy.js
+++ b/src/awfy.js
@@ -429,6 +429,7 @@ const MOBILE_APPS = {
     label: 'Fenix-WebRender',
     color: PALETTE.yellow,
     project: 'fenix',
+    platformSuffix: '-qr',
     extraOptions: ['webrender'],
   },
   geckoview: {
@@ -442,6 +443,7 @@ const MOBILE_APPS = {
     label: 'GeckoView WebRender',
     color: PALETTE.red,
     project: ALT_PROJECT,
+    platformSuffix: '-qr',
     extraOptions: ['webrender'],
   },
 };

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -27,7 +27,7 @@ it('Query info', () => {
           platform: 'linux1804-64-shippable',
           platformSuffix: undefined,
           project: 'autoland',
-          extraOptions: ['nocondprof'],
+          extraOptions: undefined,
         },
         {
           color: '#dc4c4e',
@@ -38,7 +38,7 @@ it('Query info', () => {
           platform: 'linux1804-64-shippable-qr',
           platformSuffix: '-qr',
           project: 'mozilla-central',
-          extraOptions: ['nocondprof', 'fission', 'webrender'],
+          extraOptions: ['fission', 'webrender'],
         },
         {
           color: '#ebc23f',
@@ -49,7 +49,7 @@ it('Query info', () => {
           platform: 'linux1804-64-shippable-qr',
           platformSuffix: '-qr',
           project: 'autoland',
-          extraOptions: ['nocondprof', 'webrender'],
+          extraOptions: ['webrender'],
         },
         {
           color: '#446e9e',
@@ -82,7 +82,7 @@ it('Query info', () => {
           platform: 'linux1804-64-shippable',
           platformSuffix: undefined,
           project: 'mozilla-central',
-          extraOptions: ['nocondprof'],
+          extraOptions: undefined,
         },
         {
           color: '#fe939e',
@@ -93,7 +93,7 @@ it('Query info', () => {
           platform: 'linux1804-64-shippable',
           platformSuffix: undefined,
           project: 'mozilla-central',
-          extraOptions: ['nocondprof'],
+          extraOptions: undefined,
         },
       ],
       docUrl: undefined,


### PR DESCRIPTION
A couple of bugs recently resolved caused the signatures we care about to change. The Android tests now use the -qr WebRender platforms, and we've dropped the use of 'nocondprof'. Let's hold off merging this until we have accumulated some of the new signatures, but feel free to review.