### PR TITLE
Add Samsung Galaxy S7 to mobile platforms

### DIFF
--- a/src/awfy.js
+++ b/src/awfy.js
@@ -520,6 +520,11 @@ export const CONFIG = {
       platforms: ['android-hw-p2-8-0-android-aarch64', 'android-hw-p2-8-0-android-aarch64-shippable'],
       categories: MOBILE_CATEGORIES,
     },
+    androidGalaxyS7: {
+      label: 'Android (Galaxy S7)',
+      platforms: ['android-hw-s7-8-0-android-aarch64-shippable'],
+      categories: MOBILE_CATEGORIES,
+    },
   },
 };
 

--- a/src/awfy.js
+++ b/src/awfy.js
@@ -29,7 +29,6 @@ export const AWFY_BENCHMARKS = {
         suite: 'speedometer',
         option: 'opt',
         application: 'geckoview',
-        extraOptions: ['geckoview'],
       },
       'geckoview-webrender': {
         color: PALETTE.red,
@@ -39,7 +38,7 @@ export const AWFY_BENCHMARKS = {
         platformSuffix: '-qr',
         option: 'opt',
         application: 'geckoview',
-        extraOptions: ['geckoview'],
+        extraOptions: ['webrender'],
       },
       fenix: {
         color: PALETTE.orange,
@@ -48,7 +47,6 @@ export const AWFY_BENCHMARKS = {
         suite: 'speedometer',
         option: 'opt',
         application: 'fenix',
-        extraOptions: ['fenix'],
       },
       'fenix-webrender': {
         color: PALETTE.yellow,
@@ -58,7 +56,7 @@ export const AWFY_BENCHMARKS = {
         platformSuffix: '-qr',
         option: 'opt',
         application: 'fenix',
-        extraOptions: ['fenix'],
+        extraOptions: ['webrender'],
       },
     },
     label: 'Speedometer',


### PR DESCRIPTION
These tests should run for the first time on Saturday 17th July. We should hold off merging until we can confirm results are shown in the deploy preview.