### PR TITLE
Add google docs canvas preview to warm page load site list

### DIFF
--- a/src/awfy.js
+++ b/src/awfy.js
@@ -3,7 +3,6 @@ import { queryInfoGen } from './config-utils';
 import { BENCHMARKS as AWSY_BENCHMARKS, DEFAULT_CATEGORIES as AWSY_CATEGORIES } from './awsy';
 import { BENCHMARKS as H3_BENCHMARKS, DEFAULT_SUITES as H3_SUITES } from './h3';
 
-
 const TALOS_FRAMEWORK_ID = 1;
 const JSBENCH_FRAMEWORK_ID = 11;
 const BROWSERTIME_FRAMEWORK_ID = 13;
@@ -302,6 +301,7 @@ const SITES = {
   google: 'Google',
   'google-accounts': 'Google Accounts',
   'google-docs': 'Google Docs',
+  'google-docs-canvas': 'Google Docs Canvas Preview',
   'google-search': 'Google',
   'google-slides': 'Google Slides',
   'google-mail': 'Google Mail',


### PR DESCRIPTION
Google Docs is going to be switching to a canvas-based rendering. This PR adds the page load test for the canvas preview to the AWFY site list