### PR TITLE
Add JetStream 2 benchmark results

### DIFF
--- a/src/awfy.js
+++ b/src/awfy.js
@@ -183,6 +183,7 @@ const RAPTOR_TESTS = {
   ares6: { label: 'Ares6' },
   'wasm-godot': { label: 'WebAssembly Godot' },
   'wasm-misc': { label: 'WebAssembly Embenchen' },
+  jetstream2: { label: 'JetStream 2' },
 };
 
 const RAPTOR_BENCHMARKS = {};


### PR DESCRIPTION
I noticed we aren't showing the JetStream 2 results.