### PR TITLE
FXP-2435 Disable P2 perf tests

### DIFF
--- a/src/awfy.js
+++ b/src/awfy.js
@@ -483,11 +483,6 @@ export const CONFIG = {
       platforms: ['android-hw-g5-7-0-arm7-shippable-qr', 'android-hw-g5-7-0-arm7-api-16-shippable-qr'],
       categories: MOBILE_CATEGORIES,
     },
-    androidPixel2: {
-      label: 'Android (Google Pixel 2)',
-      platforms: ['android-hw-p2-8-0-android-aarch64-shippable-qr'],
-      categories: MOBILE_CATEGORIES,
-    },
     androidGalaxyS7: {
       label: 'Android (Samsung Galaxy S7)',
       platforms: ['android-hw-s7-8-0-android-aarch64-shippable-qr'],


### PR DESCRIPTION
Removing Google Pixel 2 from AWFY as part of FXP-2435