### PR TITLE
Bug 1893971 - Fix AWFY graphs to show fenix data from mozilla-central/autoland instead of firefox-android

### DIFF
--- a/src/awfy.js
+++ b/src/awfy.js
@@ -360,14 +360,14 @@ const MOBILE_APPS = {
     name: 'fenix',
     label: 'Fenix-nofis',
     color: PALETTE.orange,
-    project: 'firefox-android',
+    project: ALT_PROJECT,
     extraOptions: ['webrender'],
   },
   'fenix-fission': {
     name: 'fenix',
     label: 'Fenix-fission',
     color: PALETTE.emerald,
-    project: 'firefox-android',
+    project: ALT_PROJECT,
     extraOptions: ['webrender', 'fission'],
   },
   geckoview: {


### PR DESCRIPTION
Updated the awfy codebase to use m-c/autoland rather than the pre-mono repo firefox-android