### PR TITLE
Bug-1893971-fix-awfy-graph-post-monorepo

### DIFF
--- a/src/awfy.js
+++ b/src/awfy.js
@@ -367,7 +367,7 @@ const MOBILE_APPS = {
     name: 'fenix',
     label: 'Fenix-fission',
     color: PALETTE.emerald,
-    project: ALT_PROJECT,
+    project: PROJECT,
     extraOptions: ['webrender', 'fission'],
   },
   geckoview: {


### PR DESCRIPTION
Currently the AWFY graphs for Fenix nofis are using firefox-android data.
This patch make sure we use mozilla-central and autoland