### PR TITLE
Add Win 11 platform to AWFY

### DIFF
--- a/src/awfy.js
+++ b/src/awfy.js
@@ -478,6 +478,11 @@ export const CONFIG = {
       platforms: ['windows10-64-shippable-qr', 'windows10-64-2004-shippable-qr'],
       categories: DESKTOP_CATEGORIES,
     },
+    win11: {
+      label: 'Windows 11 64bit',
+      platforms: ['windows11-64-shippable-qr'],
+      categories: DEFAULT_CATEGORIES,
+    },
     androidGalaxyA51: {
       label: 'Android (Samsung Galaxy A51)',
       platforms: ['android-hw-a51-11-0-aarch64-shippable-qr'],

--- a/src/awfy.js
+++ b/src/awfy.js
@@ -481,7 +481,7 @@ export const CONFIG = {
     win11: {
       label: 'Windows 11 64bit',
       platforms: ['windows11-64-shippable-qr'],
-      categories: DEFAULT_CATEGORIES,
+      categories: DESKTOP_CATEGORIES,
     },
     androidGalaxyA51: {
       label: 'Android (Samsung Galaxy A51)',


### PR DESCRIPTION
For https://bugzilla.mozilla.org/show_bug.cgi?id=1904980

Looks as expected to me? 
<img width="921" alt="image" src="https://github.com/mozilla-frontend-infra/firefox-performance-dashboards/assets/7659976/0b211f84-2d6c-4c38-89ea-1b32ff0c9ae7">

(and I just realized you can see it yourself in the deploy preview too)