### PR TITLE
Add motionmark 1.3, update landing path, remove osx 10.14

### DIFF
--- a/src/awfy.js
+++ b/src/awfy.js
@@ -519,11 +519,6 @@ export const CONFIG = {
       platforms: ['macosx1015-64-shippable-qr'],
       categories: DESKTOP_CATEGORIES,
     },
-    mac1014: {
-      label: 'macOS 10.14 "Mojave"',
-      platforms: ['macosx1014-64-shippable-qr'],
-      categories: DESKTOP_CATEGORIES,
-    },
     mac1400: {
       label: 'macOS 14.5 "Sonoma"',
       platforms: ['macosx1400-64-shippable-qr'],

--- a/src/awfy.js
+++ b/src/awfy.js
@@ -499,7 +499,7 @@ Object.entries(SITES).forEach(([siteKey, siteLabel]) => {
 
 export const CONFIG = {
   default: {
-    landingPath: '/win10/benchmarks/overview?numDays=60',
+    landingPath: '/win11/benchmarks/overview?numDays=60',
     dayRange: 60, // # days
   },
   dayRange: [1, 2, 7, 14, 30, 60, 90, 365],

--- a/src/awfy.js
+++ b/src/awfy.js
@@ -218,6 +218,8 @@ const RAPTOR_TESTS = {
   'assorted-dom': { label: 'Assorted DOM' },
   'motionmark-animometer': { label: 'MotionMark Animometer' },
   'motionmark-htmlsuite': { label: 'MotionMark HtmlSuite' },
+  'motionmark-1-3': { label: 'MotionMark 1.3' },
+  'motionmark-htmlsuite-1-3': { label: 'MotionMark HtmlSuite 1.3' },
   speedometer: { label: 'Speedometer 2' },
   speedometer3: { label: 'Speedometer 3' },
   stylebench: { label: 'StyleBench' },


### PR DESCRIPTION
closes #520 
closes #517

There seems to be a bug where I can't remove motion mark 1.0 (e.g. #519) without the dashboard going completely blank

so for the time being we can just keep motionmark 1.0 and 1.3?