### PR TITLE
Add android config for jetstream 3

### DIFF
--- a/src/awfy.js
+++ b/src/awfy.js
@@ -444,7 +444,7 @@ const MOBILE_APPS = {
 
 const MOBILE_CATEGORIES = {
   benchmarks: {
-    suites: ['speedometer-android', 'speedometer3-android'],
+    suites: ['speedometer-android', 'speedometer3-android', 'jetstream3-android'],
     label: 'Benchmarks',
   },
   'cold-page-load': {


### PR DESCRIPTION
For https://bugzilla.mozilla.org/show_bug.cgi?id=1973989

additionally geckoview is removed from android. This will support work in #521 