### PR TITLE
Fix JetStream3 y-axis label showing  instead of  for some subtests

### DIFF
--- a/src/awfy.js
+++ b/src/awfy.js
@@ -90,6 +90,7 @@ export const AWFY_BENCHMARKS = {
       },
     },
     label: 'JetStream 3',
+    yLabel: 'Score',
   },
 };
 
@@ -232,14 +233,14 @@ const RAPTOR_TESTS = {
   'wasm-godot': { label: 'WebAssembly Godot' },
   'wasm-misc': { label: 'WebAssembly Embenchen' },
   jetstream2: { label: 'JetStream 2' },
-  jetstream3: { label: 'JetStream 3' },
+  jetstream3: { label: 'JetStream 3', yLabel: 'Score' },
   'matrix-react-bench': { label: 'Matrix React' },
 };
 
 const RAPTOR_BENCHMARKS = {};
 Object.entries(RAPTOR_TESTS).forEach(([testKey, test]) => {
   const bmKey = `raptor-desktop-${testKey}`;
-  RAPTOR_BENCHMARKS[bmKey] = { compare: {}, label: test.label };
+  RAPTOR_BENCHMARKS[bmKey] = { compare: {}, label: test.label, ...(test.yLabel && { yLabel: test.yLabel }) };
   const apps = testKey.startsWith('wasm') ? WASM_APPS : DESKTOP_APPS;
   Object.entries(apps).forEach(([appKey, app]) => {
     RAPTOR_BENCHMARKS[bmKey].compare[appKey] = {

--- a/src/components/PerfherderGraph/index.jsx
+++ b/src/components/PerfherderGraph/index.jsx
@@ -97,9 +97,9 @@ class PerferhderGraph extends React.Component {
       // We can have multiple subtests for a single call to queryPerfData
       Object.values(response).forEach(({ data, meta, perfherderUrl }) => {
         const newUrl = fixUrl(perfherderUrl, dayRange);
-        if (!chartJsOptions) {
-          chartJsOptions = generateChartJsOptions(meta, yLabel, minDate, maxDate);
-        }
+        // Use yLabel only for the parent/overview; subtests derive their label from lower_is_better
+        const isOverview = !meta.test;
+        chartJsOptions = generateChartJsOptions(meta, isOverview ? yLabel : undefined, minDate, maxDate);
         const graphUid = meta.test || `${title}-overview`;
         // Considering includeSubtests is because glvideo has the 'test' property set
         const graphTitle = !includeSubtests ? title : meta.test || title;


### PR DESCRIPTION
Closes #558

Perfherder's `lower_is_better` flag is inconsistent across platforms for the JetStream3 signature, and chartJsOptions was computed once from the first response and reused for all charts, so subtests would inherit the parent's label (or vice versa).

by setting explicit yLabel: 'Score' on the JetStream3 benchmark configs, and generating chart options **per-graph** so subtests always derive their label from their own lower_is_better metadata. 