### PR TITLE
Add MotionMark data for macOS arm64

### DIFF
--- a/src/awfy.js
+++ b/src/awfy.js
@@ -503,6 +503,7 @@ export const CONFIG = {
       label: 'macOS 15.0 "Sequoia" (AArch64)',
       platforms: ['macosx1500-aarch64-shippable'],
       categories: DESKTOP_CATEGORIES,
+      project: PROJECT,
     },
     mac1470: {
       label: 'macOS 14.7 "Sonoma" (x64)',


### PR DESCRIPTION
Just noticed that data is missing. We need to use PROJECT (mozilla-central) for this as it does not run in autoland.